### PR TITLE
Fix: broken assignament at text templates example 10

### DIFF
--- a/47_templates/01_text-templates/10_function/main.go
+++ b/47_templates/01_text-templates/10_function/main.go
@@ -21,7 +21,7 @@ func main() {
 			return strings.ToUpper(str)
 		},
 	})
-	tpl, err = tpl.ParseFiles("tpl.gohtml")
+	tpl, err := tpl.ParseFiles("tpl.gohtml")
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
Need to use a assignment shortcut ( := ), for multiple
return values context such as ParseFiles(filenames ...string) (*Template, error)